### PR TITLE
Instrument Z3 solver work and integrate memory cost

### DIFF
--- a/master_log.csv
+++ b/master_log.csv
@@ -18,3 +18,22 @@ Finite Bounded-Step Halting Experiments,0.0,264,1,1,0.0,1200,0,0,0.0
 Geometry of Truth,112.0,264,1,0,0.0,560,0,0,0.42424242424242425
 Geometry of Coherence,0.0,96,1,0,0.0,32,0,0,0.0
 Conclusion,0.0,96.0,1,0,0.0,0.0,0,0,0.0
+The Axiom of Blindness,10.0,184,1,1,0.0,120,0,0,0.05434782608695652
+Game of Life,900.0,264,4,2,0.0,680,0,0,3.409090909090909
+Lensing,0.0,0.0,1,2,0.0,0.0,0,0,0.0
+N-Body and FLRW,0.0,0.0,1,6,0.0,0.0,0,0,0.0
+Phyllotaxis,0.0,0.0,1,2,0.0,0.0,0,0,0.0
+Mandelbrot,5444.0,312,50,2,0.0,4160,0,0,17.44871794871795
+Universality,0.0,112,1,0,0.0,48,0,0,0.0
+The Thiele Machine,0.0,0.0,1,0,0.0,0.0,0,0,0.0
+NUSD Law,0.0,72,1,0,0.0,8,0,0,0.0
+Universality Demonstration,0.0,992,1,0,0.0,1432,0,0,0.0
+Physical Realization,0.0,96,2,3,0.0,32,0,0,0.0
+Scale Comparison,0.0,96,1,0,0.0,32,0,0,0.0
+Capstone Demonstration,0.0,224,1,0,0.0,224,0,0,0.0
+Process Isomorphism,0.0,280,1,0,0.0,304,0,0,0.0
+Geometric Logic,0.0,240,1,0,0.0,200,0,0,0.0
+Finite Bounded-Step Halting Experiments,0.0,264,1,1,0.0,1200,0,0,0.0
+Geometry of Truth,119.3856079,264,1,0,0.0,560,0,0,0.4522182117424242
+Geometry of Coherence,7.397656200000001,96,1,0,0.0,32,0,0,0.07705891875000001
+Conclusion,7.397656200000001,96.0,1,0,0.0,0.0,0,0,0.07705891875000001

--- a/to-do.md
+++ b/to-do.md
@@ -289,3 +289,6 @@ Phase 17: Dark Work Instrumentation
 - [x] Instrument Z3 `prove()` and solver checks to record steps, conflicts, and max memory
 - [x] Calibrate `z3_conflicts` and `z3_memory` cost coefficients using the Conclusion proof
 - [x] Re-run audit on Z3-heavy chapters with calibrated coefficients
+
+Phase 18: Ghost in the Machine Expedition
+- [x] Record Z3 solver work directly into `CostLedger` and price memory via `ZETA`


### PR DESCRIPTION
## Summary
- Track Z3 solver statistics directly on CostLedger, including max memory usage
- Extend canonical cost to account for Z3 memory via constant ZETA
- Pass CostLedger to prove() and merge solver metrics at call sites

## Testing
- `python -m py_compile thethielemachine.py`
- `python thethielemachine.py --selftest all`
- `python thethielemachine.py --no-plot`

------
https://chatgpt.com/codex/tasks/task_e_689911a609f883258690b36e5a228c53